### PR TITLE
feat(ci): release automation

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,13 @@
+branches:
+  - main
+plugins:
+  - '@semantic-release/commit-analyzer'
+  - '@semantic-release/release-notes-generator'
+  - '@semantic-release/changelog'
+  - 'semantic-release-rubygem'
+  - - '@semantic-release/git'
+    - assets:
+        - CHANGELOG.md
+        - appmap_swagger.gemspec
+        - lib/appmap/swagger/version.rb
+  - '@semantic-release/github'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,20 @@ cache: bundler
 rvm:
   - 2.6.6
 before_install: gem install bundler -v 2.1.4
+before_deploy:
+  - |
+    nvm install --lts \
+      && nvm use --lts \
+      && npm i -g \
+        semantic-release \
+        @semantic-release/git \
+        @semantic-release/changelog \
+        semantic-release-rubygem
+
+deploy:
+  - provider: script
+    script: ./release.sh
+    on:
+      branch: main
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,3 @@
 # v0.1.1
 
 * Be sure and reference global `::Rails`.
-

--- a/README_CI.md
+++ b/README_CI.md
@@ -1,0 +1,20 @@
+# Configuration variables:
+
+* `GH_TOKEN`: used by `semantic-release` to push changes to Github and manage releases
+* `GEM_HOST_API_KEY`: rubygems API key
+* `GEM_ALTERNATIVE_NAME` (optional): used for testing of CI flows, 
+to avoid publication of test releases under official package name
+
+# Release command
+
+`./release.sh` 
+
+Bash wrapper script is used merely as a launcher of `semantic-release` 
+with extra logic to explicitly determine git url from `TRAVIS_REPO_SLUG` \
+variable if its defined 
+
+# CI flow
+
+1. The version number is increased (including modicication of `lib/appmap/swagger/version.rb`)
+2. Gem is published under new version number
+3. Github release is created with the new version number

--- a/appmap_swagger.gemspec
+++ b/appmap_swagger.gemspec
@@ -5,7 +5,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'appmap/swagger/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'appmap_swagger'
+  # ability to parameterize gem name is added intentionally, 
+  # to support the possibility of unofficial releases, e.g. during CI tests
+  spec.name          = (ENV['GEM_ALTERNATIVE_NAME'].to_s.empty? ? 'appmap_swagger' : ENV["GEM_ALTERNATIVE_NAME"] )
   spec.version       = AppMap::Swagger::VERSION
   spec.authors       = ['Kevin Gilpin']
   spec.email         = ['kgilpin@gmail.com']

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# using bash wrapper as Rake blows up in `require/extentiontask` (line 10)
+
+RELEASE_FLAGS=""
+if [ ! -z "$TRAVIS_REPO_SLUG" ]; then
+    RELEASE_FLAGS="-r git+https://github.com/${TRAVIS_REPO_SLUG}.git"
+fi 
+
+if [ ! -z "$GEM_ALTERNATIVE_NAME" ]; then
+    echo "Release: GEM_ALTERNATIVE_NAME=$GEM_ALTERNATIVE_NAME"
+else
+    echo "No GEM_ALTERNATIVE_NAME is provided, releasing gem with default name ('appmap_swagger')"
+fi
+
+set -x
+exec semantic-release $RELEASE_FLAGS
+


### PR DESCRIPTION
Adds `semantic-release` flow (including rubygems release step) via travis `deploy` hook.

Configuration variables:
 * `GH_TOKEN`: used by `semantic-release` to push changes to Github and manage releases
* `GEM_HOST_API_KEY`: rubygems API key
* `GEM_ALTERNATIVE_NAME` (optional): used for testing of CI flows,
to avoid publication of test releases under official package name

**Potentially disrupting change**:

Commits to "main" branch now trigger semantic-release flow, which normally results in automatically generated Github commits, tags and releases.
